### PR TITLE
typo in citadel name

### DIFF
--- a/ign_ros2_control/package.xml
+++ b/ign_ros2_control/package.xml
@@ -12,7 +12,7 @@
   <depend>ament_index_cpp</depend>
   <!-- default version to use in official ROS2 packages is Ignition Fortress for ROS2 Rolling -->
   <depend condition="$IGNITION_VERSION == ''">ignition-gazebo6</depend>
-  <depend condition="$IGNITION_VERSION == cidadel">ignition-gazebo3</depend>
+  <depend condition="$IGNITION_VERSION == citadel">ignition-gazebo3</depend>
   <depend condition="$IGNITION_VERSION == edifice">ignition-gazebo5</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-gazebo6</depend>
   <depend>ignition-plugin</depend>


### PR DESCRIPTION
## Summary
Citadel name have a typo in the package.xml.
This change should be applied to other release branches (foxy, galactic, etc.)