### PR TITLE
typo in citadel name

### DIFF
--- a/ign_ros2_control/package.xml
+++ b/ign_ros2_control/package.xml
@@ -11,7 +11,7 @@
 
   <depend>ament_index_cpp</depend>
   <depend condition="$IGNITION_VERSION == ''">ignition-gazebo3</depend>
-  <depend condition="$IGNITION_VERSION == cidadel">ignition-gazebo3</depend>
+  <depend condition="$IGNITION_VERSION == citadel">ignition-gazebo3</depend>
   <depend condition="$IGNITION_VERSION == edifice">ignition-gazebo5</depend>
   <depend condition="$IGNITION_VERSION == fortress">ignition-gazebo6</depend>
   <depend>ignition-plugin</depend>


### PR DESCRIPTION
The same change applied to main.
Fix typo in package.xml