### PR TITLE
Install ign_ros2_control_demos/urdf directory to fix demos

### DIFF
--- a/ign_ros2_control_demos/CMakeLists.txt
+++ b/ign_ros2_control_demos/CMakeLists.txt
@@ -24,6 +24,7 @@ find_package(geometry_msgs REQUIRED)
 install(DIRECTORY
   launch
   config
+  urdf
   DESTINATION share/${PROJECT_NAME}/
 )
 


### PR DESCRIPTION
All launch scripts under `ign_ros2_control_demos` require `ign_ros2_control_demos/urdf` directory to be installed, see [example (cart_example_effort.launch.py)](https://github.com/gazebosim/gz_ros2_control/blob/29a36e0dadf4c85a5a84560235f164dfea0fcd1e/ign_ros2_control_demos/launch/cart_example_effort.launch.py#L39-L41).

The installation of `ign_ros2_control_demos/urdf` directory was disabled as a part of https://github.com/gazebosim/gz_ros2_control/pull/56, which I believe was an unintentional consequence of removing `urdf` package dependency. Therefore, this PR reverts this change.

Note: This PR targets `main` but all branches are affected (`foxy`/`galactic`).


# 🦟 Bug fix

Fixes the following error that is experienced when running launch scripts included in `ign_ros2_control_demos`.

```log
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught exception when trying to load file of format [py]: [Errno 2] No such file or directory: '/root/ws_moveit/install/ign_ros2_control_demos/share/ign_ros2_control_demos/urdf/test_cart_position.xacro.urdf'
```

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.